### PR TITLE
Fix webpack warnings

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,6 +30,6 @@
     "react": "^0.12.2"
   },
   "dependencies": {
-    "payment": "0.0.5"
+    "payment": "^0.0.10"
   }
 }


### PR DESCRIPTION
Older versions of payment were distributed with a pre-built payment.js file. Webpack does not like minified JS. It throws errors like:

```
lib/payment.js
Critical dependencies:
1:459-466 This seems to be a pre-built javascript file. Though this is possible, it's not recommended. Try to require the original source to get better results.
```

Bumping the version of payment to the latest fixes this. 

Payment issue for reference: https://github.com/jessepollak/payment/issues/15
